### PR TITLE
Add Book-Crossing and Last.fm names to output files

### DIFF
--- a/src/utils/book_crossing_etl/bookcrossing.py
+++ b/src/utils/book_crossing_etl/bookcrossing.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
             )
     parser.add_argument(
             '-o',
-            '--output_directory',
+            '--output-directory',
             type=str,
             action="store",
             help="the directory to save the output JSON files, by default the current directory",

--- a/src/utils/book_crossing_etl/bookcrossing.py
+++ b/src/utils/book_crossing_etl/bookcrossing.py
@@ -257,8 +257,8 @@ if __name__ == "__main__":
 
     with\
         open(args.ratings, 'rb') as csvfile,\
-        open("implicit_ratings.json", 'w') as imp,\
-        open("explicit_ratings.json", 'w') as exp:
+        open("book-crossing_implicit_ratings.json", 'w') as imp,\
+        open("book-crossing_explicit_ratings.json", 'w') as exp:
 
         for line in iter_lines(csvfile):
             ret = parse_rating_line(line)
@@ -275,11 +275,11 @@ if __name__ == "__main__":
     # outputs.
     rated_and_valid_users = set(rated_users)
 
-    with open("books.json", 'w') as f:
+    with open("book-crossing_books.json", 'w') as f:
         for ret in book_data:
             f.write(json.dumps(ret) + '\n')
 
-    with open("users.json", 'w') as f:
+    with open("book-crossing_users.json", 'w') as f:
         for ret in users_data:
             if ret["user_id"] in rated_and_valid_users:
                 f.write(json.dumps(ret) + '\n')

--- a/src/utils/jester_etl/jester.py
+++ b/src/utils/jester_etl/jester.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
             )
     parser.add_argument(
             '-o',
-            '--output_directory',
+            '--output-directory',
             type=str,
             action="store",
             help="the directory to save the output JSON files, by default the current directory",

--- a/src/utils/lastfm_etl/lastfm.py
+++ b/src/utils/lastfm_etl/lastfm.py
@@ -287,11 +287,11 @@ if __name__ == "__main__":
 
     # Parse the files
     processing_queue = (
-        (args.artists, args.output_directory + "/artists.json", parse_artist_line),
-        (args.tags, args.output_directory + "/tags.json", parse_tag_line),
-        (args.friends, args.output_directory + "/friends.json", parse_friends_line),
-        (args.applied_tags, args.output_directory + "/applied_tags.json", parse_applied_tag_line),
-        (args.plays, args.output_directory + "/plays.json", parse_plays_line),
+        (args.artists, args.output_directory + "/lastfm_artists.json", parse_artist_line),
+        (args.tags, args.output_directory + "/lastfm_tags.json", parse_tag_line),
+        (args.friends, args.output_directory + "/lastfm_friends.json", parse_friends_line),
+        (args.applied_tags, args.output_directory + "/lastfm_applied_tags.json", parse_applied_tag_line),
+        (args.plays, args.output_directory + "/lastfm_plays.json", parse_plays_line),
     )
     for input_file, output_file, function in processing_queue:
         with open(input_file, 'rb') as csv_file, open(output_file, 'w') as json_file:

--- a/src/utils/lastfm_etl/lastfm.py
+++ b/src/utils/lastfm_etl/lastfm.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":
             )
     parser.add_argument(
             '-o',
-            '--output_directory',
+            '--output-directory',
             type=str,
             action="store",
             help="the directory to save the output JSON files, by default the current directory",

--- a/src/utils/movielens_etl/ml10m_to_json.py
+++ b/src/utils/movielens_etl/ml10m_to_json.py
@@ -25,7 +25,7 @@ parser.add_argument(
         )
 parser.add_argument(
         '-o',
-        '--output_directory',
+        '--output-directory',
         type=str,
         action="store",
         help="the directory to save the output JSON files, by default the current directory",

--- a/src/utils/movielens_etl/ml1m_to_json.py
+++ b/src/utils/movielens_etl/ml1m_to_json.py
@@ -20,7 +20,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '-o',
-    '--output_directory',
+    '--output-directory',
     type=str,
     action="store",
     help="the directory to save the output JSON files, by default the current directory",

--- a/src/utils/movielens_etl/ml20m_to_json.py
+++ b/src/utils/movielens_etl/ml20m_to_json.py
@@ -30,7 +30,7 @@ parser.add_argument(
         )
 parser.add_argument(
         '-o',
-        '--output_directory',
+        '--output-directory',
         type=str,
         action="store",
         help="the directory to save the output JSON files, by default the current directory",


### PR DESCRIPTION
Instead of saving a file with a generic name (like `users.json`), instead we now prepend the dataset name  (for example, `lastfm_users.json`). This was the case for all previous datasets, but was forgotten for Book-crossing and Last.fm.

Additionally, change the flag for the output directory from `--output_directory` to `--output-directory`, which is the only sane way to use multi-word commandline flags.