### PR TITLE
Fix a bug with non-ascii characters in names

### DIFF
--- a/src/utils/code_etl/blame_to_json.py
+++ b/src/utils/code_etl/blame_to_json.py
@@ -114,14 +114,17 @@ def block_to_JSON(block, filename, repo_name=None):
     # Function to convert timezone to hour office integer
     def tz_int(tz): return int(tz, 10)
 
+    # Function to clean out non-ascii characters
+    def clean_text(text): return ''.join([i if ord(i) < 128 else '' for i in text])
+
     # Translation from the porcelain key to the key in our JSON object, as well
     # as an option transformation to apply first
     porcelain_to_json = {
-        "author": ("author", None),
+        "author": ("author", clean_text),
         "author-mail": ("author_mail", clean_email),
         "author-time": ("author_time", int),
         "author-tz": ("author_timezone", tz_int),
-        "committer": ("committer", None),
+        "committer": ("committer", clean_text),
         "committer-mail": ("committer_mail", clean_email),
         "committer-time": ("committer_time", int),
         "committer-tz": ("committer_timezone", tz_int),

--- a/src/utils/code_etl/user_to_file_mapper.py
+++ b/src/utils/code_etl/user_to_file_mapper.py
@@ -142,6 +142,19 @@ def parse_block(block, file_map):
                 file_map[file] = [(name, email)]
 
 
+def clean_text(text):
+    """ Remove non-ascii characters from a string.
+
+    Args:
+        text (str): A string.
+
+    Returns:
+        str: A string with all characters with ord() >= 128 removed.
+
+    """
+    return ''.join([i if ord(i) < 128 else '' for i in text])
+
+
 def file_map_to_json(file_map, repo_name):
     """Returns a list of JSON objects as strings containing the `git log`
     information.
@@ -160,8 +173,8 @@ def file_map_to_json(file_map, repo_name):
         for key, count in counter.iteritems():
             current_json = deepcopy(JSON_LINE)
             current_json["repo_name"] = repo_name
-            current_json["author"] = key[0]
-            current_json["author_mail"] = key[1]
+            current_json["author"] = clean_text(key[0])
+            current_json["author_mail"] = clean_text(key[1])
             current_json["filename"] = file
             current_json["edit_count"] = count
             jsons.append(json.dumps(current_json))


### PR DESCRIPTION
When converting a git repo to JSON, non-ascii characters (especially
non-ascii and non-UTF8 characters) cause a crash. Since these characters
are not needed (we do not need an exact name, just a unique name for
each entity) we discard them.