### PR TITLE
Fix bug where the Jester rating is sometimes None

### DIFF
--- a/src/utils/jester_etl/jester.py
+++ b/src/utils/jester_etl/jester.py
@@ -78,6 +78,9 @@ def row_to_jsons(row, user_id):
         # 99 is used as the NULL character
         if val == 99:
             continue
+        # Sometimes the value is empty
+        if not val:
+            continue
         # Otherwise element i corresponds to the rating for joke i
         current_rating = deepcopy(RATINGS)
         current_rating["user_id"] = user_id


### PR DESCRIPTION
Sometimes the data has empty strings, which leads to `None` in the final output. If the rating string is empty, we now discard the rating.