### PR TITLE
Remove unneeded spark context

### DIFF
--- a/src/algorithms/dataset_stats.py
+++ b/src/algorithms/dataset_stats.py
@@ -1,8 +1,7 @@
-def get_dataset_stats(sc, *args):
+def get_dataset_stats(*args):
     """Calculate characteristic statistics about a dataset.
 
     Args:
-        sc: a spark context
         *args: RDDs that cover exactly 100% of the dataset without duplication
             when combined.
 

--- a/src/hermes_run_script.py
+++ b/src/hermes_run_script.py
@@ -176,7 +176,7 @@ class hermes_run():
             content_vect = sl.load_from_hadoop(content_path, self.sc)
 
             # Calculate statistics about the dataset
-            stats = dataset_stats.get_dataset_stats(self.sc, train_ratings, test_ratings)
+            stats = dataset_stats.get_dataset_stats(train_ratings, test_ratings)
 
             for cf_pred in self.cf_predictions:
 
@@ -221,7 +221,7 @@ class hermes_run():
                 test_ratings = sl.load_from_hadoop(test_ratings_loc, self.sc)
 
                 # Calculate statistics about the dataset
-                stats = dataset_stats.get_dataset_stats(self.sc, train_ratings, test_ratings)
+                stats = dataset_stats.get_dataset_stats(train_ratings, test_ratings)
 
                 for cb_pred in self.cb_predictions:
 


### PR DESCRIPTION
`sc` was needed when using `sc.union()`, but the notation was changed to `+=` so `sc` is no longer required.